### PR TITLE
Deploy stacks using ChangeSet to support SAM layers

### DIFF
--- a/humilis/config.py
+++ b/humilis/config.py
@@ -33,7 +33,8 @@ class Config():
     KEYS_DIR = os.path.join(os.path.expanduser('~'), '.ssh')
     # Default amount of time to wait for CF to carry out an operation
     CF_TEMPLATE_VERSION = datetime.date(2010, 9, 9)
-    LAYER_SECTIONS = ['parameters', 'mappings', 'resources', 'outputs']
+    LAYER_SECTIONS = ['parameters', 'mappings', 'resources', 'outputs',
+                      'transform']
     LOG_LEVEL = 'info'
 
     # Coloring for the events' messages

--- a/humilis/environment.py
+++ b/humilis/environment.py
@@ -50,7 +50,8 @@ class Environment():
         self.meta = meta.get(self.name)
 
         if len(self.meta) == 0:
-            raise FileFormatError(yml_path, logger=self.logger)
+            raise FileFormatError(yml_path, "Error getting environment name ",
+                                  logger=self.logger)
 
         self.cf = Cloudformation(config.boto_config)
         self.sns_topic_arn = self.meta.get('sns-topic-arn', [])

--- a/humilis/exceptions.py
+++ b/humilis/exceptions.py
@@ -29,7 +29,7 @@ class FileFormatError(LoggedException):
     def __init__(self, filename, msg=None, *args, **kwargs):
         message = "Wrongly formatted file {}".format(filename)
         if msg is not None:
-            message = msg + " : " + msg
+            message = msg + " : " + message
         super(FileFormatError, self).__init__(message, *args, **kwargs)
 
 
@@ -38,7 +38,7 @@ class RequiresVaultError(LoggedException):
     def __init__(self, msg=None, *args, **kwargs):
         message = "Requires a secrets-vault layer in the environment"
         if msg is not None:
-            message = msg + " : " + msg
+            message = msg + " : " + message
         super(RequiresVaultError, self).__init__(message, *args, **kwargs)
 
 

--- a/humilis/utils.py
+++ b/humilis/utils.py
@@ -127,7 +127,8 @@ class DirTreeBackedObject(TemplateLoader):
                 continue
 
             if len(this_data) != 1:
-                raise FileFormatError(filename, self.logger)
+                raise FileFormatError(filename, "Error loading layer section",
+                                      self.logger)
 
             data_key = list(this_data.keys())[0]
             if data_key.lower() != section.lower():


### PR DESCRIPTION
In order to support SAM model layers, it is necessary to deploy CF
stacks using ChangeSets. Consequently the entire way we are deploying
(wether it is creating a new one or an updating an old one) stacks has
been modified.

I didn't add any testing yet, I want to be sure that the approach is correct before doing so.
Nevertheless I have tested all the cases manually and it works fine.