### PR TITLE
Deploy stacks using ChangeSet to support SAM layers

### DIFF
--- a/examples/layers/instance-2/meta/main.yml
+++ b/examples/layers/instance-2/meta/main.yml
@@ -23,7 +23,7 @@ meta:
                         layer_name: vpc
                         resource_name: VPC
         subnet:
-            description: The physical ID of the subnet where the instance will be 
+            description: The physical ID of the subnet where the instance will be
                 launched
             value:
                 ref:

--- a/humilis/config.py
+++ b/humilis/config.py
@@ -33,7 +33,8 @@ class Config():
     KEYS_DIR = os.path.join(os.path.expanduser('~'), '.ssh')
     # Default amount of time to wait for CF to carry out an operation
     CF_TEMPLATE_VERSION = datetime.date(2010, 9, 9)
-    LAYER_SECTIONS = ['parameters', 'mappings', 'resources', 'outputs']
+    LAYER_SECTIONS = ['parameters', 'mappings', 'resources', 'outputs',
+                      'transform']
     LOG_LEVEL = 'info'
 
     # Coloring for the events' messages

--- a/humilis/environment.py
+++ b/humilis/environment.py
@@ -50,7 +50,8 @@ class Environment():
         self.meta = meta.get(self.name)
 
         if len(self.meta) == 0:
-            raise FileFormatError(yml_path, logger=self.logger)
+            raise FileFormatError(yml_path, "Error getting environment name ",
+                                  logger=self.logger)
 
         self.cf = Cloudformation(config.boto_config)
         self.sns_topic_arn = self.meta.get('sns-topic-arn', [])

--- a/humilis/exceptions.py
+++ b/humilis/exceptions.py
@@ -29,7 +29,7 @@ class FileFormatError(LoggedException):
     def __init__(self, filename, msg=None, *args, **kwargs):
         message = "Wrongly formatted file {}".format(filename)
         if msg is not None:
-            message = msg + " : " + msg
+            message = msg + " : " + message
         super(FileFormatError, self).__init__(message, *args, **kwargs)
 
 
@@ -38,7 +38,7 @@ class RequiresVaultError(LoggedException):
     def __init__(self, msg=None, *args, **kwargs):
         message = "Requires a secrets-vault layer in the environment"
         if msg is not None:
-            message = msg + " : " + msg
+            message = msg + " : " + message
         super(RequiresVaultError, self).__init__(message, *args, **kwargs)
 
 

--- a/humilis/layer.py
+++ b/humilis/layer.py
@@ -16,6 +16,7 @@ from botocore.exceptions import ClientError
 import json
 import time
 import datetime
+from uuid import uuid4
 
 
 class Layer:
@@ -193,6 +194,8 @@ class Layer:
             'Resources': self.section.get('resources', {}),
             'Outputs': self.section.get('outputs', {})
         }
+        if self.section.get('transform', {}).get('value', {}):
+            cf_template['Transform'] = self.section['transform']['value']
         return cf_template
 
     def populate_params(self):
@@ -280,47 +283,58 @@ class Layer:
                 self.name, self.cf_name))
 
             cf_template = json.dumps(self.compile(), indent=4)
-            try:
-                self.cf.create_stack(
-                    self.cf_name,
-                    cf_template,
-                    self.sns_topic_arn,
-                    self.tags)
-                self.wait_for_status_change()
-            except ClientError:
-                self.logger.error(
-                    "Error deploying stack '{}'".format(self.cf_name))
-                self.logger.error("Stack template: {}".format(cf_template))
-                raise
+            self.create_with_changeset(cf_template)
         elif update:
-            self.logger.info("Updating layer '{}'".format(self.name))
             cf_template = json.dumps(self.compile(), indent=4)
             try:
-                self.cf.update_stack(
-                    self.cf_name,
-                    cf_template,
-                    self.sns_topic_arn)
-                self.wait_for_status_change()
+                self.create_with_changeset(cf_template, update)
             except NoUpdatesError:
-                msg = "No updates on layer '{}'".format(self.name)
+                msg = "Nothing to update on stack '{}'".format(self.cf_name)
                 self.logger.warning(msg)
-            except:
-                self.logger.error(
-                    "Error deploying stack '{}'".format(self.cf_name))
-                self.logger.error("Stack template: {}".format(cf_template))
-                raise
         else:
             msg = "Layer '{}' already in CF: not creating".format(self.name)
             self.logger.info(msg)
 
-
         return self.outputs
+
+    def create_with_changeset(self, cf_template, update=False):
+        """Use a changeset to create a stack."""
+        changeset_type = "CREATE"
+        if update:
+            changeset_type = "UPDATE"
+        changeset_name = self.cf_name + str(uuid4())
+        try:
+            self.cf.client.create_change_set(
+                StackName=self.cf_name,
+                TemplateBody=cf_template,
+                Capabilities=["CAPABILITY_IAM"],
+                NotificationARNs=self.sns_topic_arn,
+                Tags=[{"Key": k, "Value": v} for k, v in self.tags.items()],
+                ChangeSetName=changeset_name,
+                ChangeSetType=changeset_type)
+            self.wait_for_status_change()
+            self.wait_changeset_creation(changeset_name)
+            if update:
+                changeset = self.cf.client.describe_change_set(
+                    ChangeSetName=changeset_name,
+                    StackName=self.cf_name)
+                if not changeset["Changes"]:
+                    raise NoUpdatesError("Nothing to update")
+            self.cf.client.execute_change_set(ChangeSetName=changeset_name,
+                                              StackName=self.cf_name)
+            self.wait_for_status_change()
+        except ClientError:
+            self.logger.error(
+                "Error deploying stack '{}'".format(self.cf_name))
+            self.logger.error("Stack template: {}".format(cf_template))
+            raise
 
     def wait_for_status_change(self):
         """Wait for the status deployment state to change."""
         status = self.watch_events()
         if status is None \
-                or status not in {'CREATE_COMPLETE', 'UPDATE_COMPLETE'}:
+                or status not in {"CREATE_COMPLETE", "UPDATE_COMPLETE",
+                                  "REVIEW_IN_PROGRESS"}:
             msg = "Unable to deploy layer '{}': status is {}".format(
                 self.name, status)
             raise CloudformationError(msg, logger=self.logger)
@@ -353,6 +367,22 @@ class Layer:
             time.sleep(5)
             stack_status = self.cf.get_stack_status(self.cf_name)
         return stack_status
+
+    def wait_changeset_creation(self, changeset_name,
+                                progress_status={"CREATE_PENDING",
+                                                 "CREATE_IN_PROGRESS"}):
+        """Wait for a changeset to be in the right status to be executed."""
+        status = self.cf.client.describe_change_set(
+            ChangeSetName=changeset_name, StackName=self.cf_name)["Status"]
+        while (status is None) or (status in progress_status):
+            status = self.cf.client.describe_change_set(
+                ChangeSetName=changeset_name, StackName=self.cf_name)["Status"]
+            time.sleep(5)
+        if status != "CREATE_COMPLETE":
+            msg = "Unable to deploy layer '{}': changeset status is {}".format(
+                self.name, status)
+            raise CloudformationError(msg, logger=self.logger)
+        return status
 
     def __repr__(self):
         return str(self)

--- a/humilis/reference.py
+++ b/humilis/reference.py
@@ -6,8 +6,9 @@ import importlib
 import pip
 import subprocess
 from subprocess import CalledProcessError
-import tempfile
 import shutil
+import tempfile
+import uuid
 from zipfile import ZipFile
 
 import boto3facade
@@ -364,3 +365,43 @@ def boto3(layer, config, service=None, call=None, output_attribute=None,
         return result.get(output_key)
     else:
         return result
+
+
+def j2_template(layer, config, path=None, s3_upload=False, params=None):
+    """Render a j2 template and return the local or s3 path of the result.
+
+    :param layer: The layer object for the layer declaring the reference.
+    :param config: An object holding humilis configuration options.
+    :param path: The path of the j2 template to render. Relative to meta.yml.
+    :param s3_upload: Upload the rendered template to s3 or not.
+    :param params: A dict containing the values to render the template.
+
+    :returns: The local or s3 path of the rendered template.
+    """
+    if params is None:
+        msg = ("Missing params for j2 rendering in layer '{}' "
+               "and env '{}'").format(layer.name, layer.env_name)
+        ref = "j2_template '{}')".format(path)
+        raise ReferenceError(ref, msg, logger=layer.logger)
+    basefile, j2_ext = os.path.splitext(path)
+    if j2_ext not in {".j2"}:
+        msg = ("The file is not a Jinja2 template. layer : '{}', "
+               "env : '{}'".format(layer.name, layer.env_name))
+        ref = "j2_template '{}')".format(path)
+        raise ReferenceError(ref, msg, logger=layer.logger)
+
+    _, ext = os.path.splitext(basefile)
+    _, filename = os.path.split(path)
+    env = jinja2.Environment(
+        extensions=["jinja2.ext.with_"],
+        loader=jinja2.FileSystemLoader(layer.basedir))
+    result = env.get_template(filename).render(params)
+    output_path = os.path.join(layer.env_basedir, "ref-j2_template_" +
+                               str(uuid.uuid4()) + ext)
+    with open(output_path, "w") as f:
+        f.write(result)
+    if s3_upload:
+        s3path = file(layer, config, output_path)
+        return s3path
+
+    return output_path

--- a/humilis/reference.py
+++ b/humilis/reference.py
@@ -82,7 +82,10 @@ def file(layer, config, path=None):
     s3 = S3(config)
     s3.cp(full_path, s3bucket, s3key)
     layer.logger.info("{} -> {}/{}".format(full_path, s3bucket, s3key))
-    return {'s3bucket': s3bucket, 's3key': s3key}
+    if layer.type == "sam":
+        return os.path.join("s3://", s3bucket, s3key)
+    else:
+        return {'s3bucket': s3bucket, 's3key': s3key}
 
 
 def lambda_ref(layer, config, path=None, dependencies=None):

--- a/humilis/utils.py
+++ b/humilis/utils.py
@@ -127,7 +127,8 @@ class DirTreeBackedObject(TemplateLoader):
                 continue
 
             if len(this_data) != 1:
-                raise FileFormatError(filename, self.logger)
+                raise FileFormatError(filename, "Error loading layer section",
+                                      self.logger)
 
             data_key = list(this_data.keys())[0]
             if data_key.lower() != section.lower():

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
             "output=humilis.reference:output",           # For backwards compat
             "environment_resource=humilis.reference:environment",
             "layer_output=humilis.reference:output",
-            "boto3=humilis.reference:boto3"],
+            "boto3=humilis.reference:boto3",
+            "j2_template=humilis.reference:j2_template"],
         "humilis.jinja2_filters": [
             "password=humilis.j2:password",
             "is_list=humilis.j2:is_list",


### PR DESCRIPTION
In order to support SAM model layers, it is necessary to deploy CF
stacks using ChangeSets. Consequently the entire way we are deploying
(wether it is creating a new one or an updating an old one) stacks has
been modified.

I didn't add any testing yet, I want to be sure that the approach is correct before doing so.
Nevertheless I have tested `create` and `update` manually and it works fine both for SAM layer and classic layers (I tested it on the elasticache layer).