### PR TITLE
Fix reference j2_template

### DIFF
--- a/humilis/reference.py
+++ b/humilis/reference.py
@@ -401,7 +401,10 @@ def j2_template(layer, config, path=None, s3_upload=False, params=None):
     with open(output_path, "w") as f:
         f.write(result)
     if s3_upload:
-        s3path = file(layer, config, output_path)
-        return s3path
+        s3bucket, s3key = _get_s3path(layer, config, output_path)
+        s3 = S3(config)
+        s3.cp(output_path, s3bucket, s3key)
+        layer.logger.info("{} -> {}/{}".format(output_path, s3bucket, s3key))
+        return os.path.join("s3://", s3bucket, s3key)
 
     return output_path


### PR DESCRIPTION
@germangh PR ready for review
Just changed the way the processed template is uploaded to s3 for the reference `j2_template`. It had to be different than the function `s3path = file(layer, config, output_path)`