### PR TITLE
[chore]: Pin pip version to 9.0.3 version as the latest breaks humilis

### DIFF
--- a/humilis/__init__.py
+++ b/humilis/__init__.py
@@ -4,5 +4,5 @@ import os
 import inspect
 
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 __dir__ = os.path.dirname(inspect.getfile(inspect.currentframe()))

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,11 @@ setup(
         "boto3",
         "s3keyring>=0.2.3",
         "boto3facade>=0.5.9",
-        "jinja2"],
+        "jinja2",
+        # The latest pip version breaks humilis as the API pip.main was removed
+        # Before updating to latest pip version (10.x.x) check this:
+        # https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
+        "pip==9.0.3"],
     classifiers=[
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3"],


### PR DESCRIPTION
The latest pip version has no more public api (pip.main) that is used by humilis. So, for now we need to pin pip's version until we fix it for good.